### PR TITLE
DM-47125 Add unit test for ccdexposure insert with multi-column primary keys

### DIFF
--- a/Dockerfile.pytest
+++ b/Dockerfile.pytest
@@ -1,4 +1,4 @@
-ARG OBS_LSST_VERSION=w_2024_32
+ARG OBS_LSST_VERSION=w_2024_46
 FROM lsstsqre/centos:7-stack-lsst_distrib-${OBS_LSST_VERSION}
 USER root
 

--- a/tests/test_pqserver.py
+++ b/tests/test_pqserver.py
@@ -287,6 +287,50 @@ def test_schema_table(lsstcomcamsim, astropy_tables):
         assert column in result.keys()
 
 
+@pytest.mark.parametrize("lsstcomcamsim", ["cdb_latiss"], indirect=True)
+def test_missing_primary_key(lsstcomcamsim):
+    client = lsstcomcamsim
+
+    response = client.post(
+        "/consdb/insert/latiss/exposure/obs/2024032100003",
+        json={
+            "values": {
+                "exposure_name": "AT_O_20240327_000002",
+                "controller": "O",
+                "day_obs": 20240327,
+                "seq_num": 2,
+            },
+        },
+    )
+    _assert_http_status(response, 200)
+    result = response.json()
+    assert result == {
+        "message": "Data inserted",
+        "table": "cdb_latiss.exposure",
+        "instrument": "latiss",
+        "obs_id": 2024032100003,
+    }
+
+    response = client.post(
+        "/consdb/insert/latiss/ccdexposure/obs/8675309",
+        json={
+            "values": {
+                "s_region": "testregion",
+                "exposure_id": 2024032100003,
+                "detector": 0,
+            },
+        },
+    )
+    _assert_http_status(response, 200)
+    result = response.json()
+    assert result == {
+        "message": "Data inserted",
+        "table": "cdb_latiss.ccdexposure",
+        "instrument": "latiss",
+        "obs_id": 8675309,
+    }
+
+
 def test_validate_unit():
     os.environ["POSTGRES_URL"] = "sqlite://"
     from lsst.consdb import pqserver


### PR DESCRIPTION
 I verified that the unit test works as intended by the following procedure:
 
```
 git switch --detach b5b38981d56f3f19989fbf388f77ca00fb5ee69c
 git cherry-pick a81aefd
 # In ./Dockerfile.pytest, change OBS_LSST_VERSION=w_2024_32 to OBS_LSST_VERSION=d_latest
 docker run -it $(docker build -q -f Dockerfile.pytest .)
 # the test fails
 git switch tickets/DM-47125
 # the change to Dockerfile.pytest carries over
 # and the test passes
```

 I also updated the Dockerfile.pytest to use a more recent build of the LSST environment.