### PR TITLE
DM-47507: Preserve text after the ticket name in the migration comment

### DIFF
--- a/.github/workflows/migrate.yaml
+++ b/.github/workflows/migrate.yaml
@@ -81,7 +81,8 @@ jobs:
         run: |
           export SDM_SCHEMAS_DIR=${{ github.workspace }}/sdm_schemas
           echo "SDM_SCHEMAS_DIR=$SDM_SCHEMAS_DIR"
-          python alembic-autogenerate.py ${{ env.TICKET_NAME }}
+          MIGRATION_COMMENT=$(echo ${{ env.BRANCH_NAME }} | sed -E 's/^tickets\///')
+          python alembic-autogenerate.py $MIGRATION_COMMENT
           if git diff --quiet; then
             echo "No changes detected."
             exit 0


### PR DESCRIPTION
Instead of generating a migration comment like "dm_12345" on a branch like "DM-12345-do-something", preserve the text after the ticket name so that the script name will look like "dm_12345_do_something". The extra text can be used as a short indication of what the migration script is doing.