### PR TITLE
OSW-21/OSW-284: Validate table and column names

### DIFF
--- a/python/lsst/consdb/cdb_schema.py
+++ b/python/lsst/consdb/cdb_schema.py
@@ -190,7 +190,7 @@ class InstrumentTable:
         query_result = db.execute(query).first()
 
         if not query_result:
-            raise BadValueException(f"Exposure ID: {exposure_id} - no such exposure ID")
+            raise BadValueException("exposure_id", exposure_id)
         return (query_result.day_obs, query_result.seq_num)
 
     def refresh_flexible_metadata_schema(self, obs_type: str):

--- a/python/lsst/consdb/handlers/external.py
+++ b/python/lsst/consdb/handlers/external.py
@@ -198,7 +198,7 @@ def insert_flexible_metadata(
         # check value against dtype
         dtype = schema[key][0]
         if dtype != type(value).__name__:
-            raise BadValueException(f"{dtype} value", value)
+            raise BadValueException(f"{dtype} value", value, [type(value).__name__])
 
     has_multi_column_primary_keys = (
         instrument_table.get_schema_version() >= Version("3.2.0") and obs_type == "exposure"
@@ -258,6 +258,10 @@ def insert(
     table_name = table.lower()
     if not table.lower().startswith(schema):
         table_name = schema + table_name
+
+    if table_name not in instrument_table.schemas.tables:
+        raise BadValueException("table", table_name, list(instrument_table.schemas.tables.keys()))
+
     table_obj = instrument_table.schemas.tables[table_name]
 
     valdict = data.values


### PR DESCRIPTION
This PR combines OSW-21 and OSW-284, since both of those are small changes.

* A few instances of BadValueException are fixed. 
* A BadValueException is added to check that the table name is valid for `insert`
* A function is added to validate the dictionary to be inserted fro `insert` and `insert_multiple`.