### PR TITLE
OSW-2388: Fix database connection pool exhaustion in ConsDB pqserver insert path.

### DIFF
--- a/python/lsst/consdb/cdb_schema.py
+++ b/python/lsst/consdb/cdb_schema.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+from contextlib import contextmanager
 from enum import StrEnum
 from typing import Any, Generator
 
@@ -152,6 +153,21 @@ class InstrumentTable:
                 self.flexible_metadata_schemas[obs_type] = None
                 self.refresh_flexible_metadata_schema(obs_type)
 
+    @contextmanager
+    def _borrow_db(self) -> Generator[Session, None, None]:
+        """Yield a Session and guarantee its return to the pool.
+
+        ``get_db`` is a generator; advancing it checks out a pooled connection
+        and closing it runs the ``finally: db.close()`` that returns the
+        connection. The ``finally`` here ensures that happens even if the
+        caller's query raises.
+        """
+        db_gen = self.get_db()
+        try:
+            yield next(db_gen)
+        finally:
+            db_gen.close()
+
     def get_timestamp_columns(self, table: str) -> set[str]:
         """Returns a set containing all timestamp columns.
 
@@ -185,8 +201,8 @@ class InstrumentTable:
             exposure_table.c.exposure_id == exposure_id
         )
 
-        db = next(self.get_db())
-        query_result = db.execute(query).first()
+        with self._borrow_db() as db:
+            query_result = db.execute(query).first()
 
         if not query_result:
             raise BadValueException("exposure_id", exposure_id)
@@ -201,8 +217,8 @@ class InstrumentTable:
             ccd_table.c.detector,
         ).where(ccd_table.c.ccdexposure_id == ccdexposure_id)
 
-        db = next(self.get_db())
-        query_result = db.execute(query).first()
+        with self._borrow_db() as db:
+            query_result = db.execute(query).first()
 
         if not query_result:
             raise BadValueException("ccdexposure_id", ccdexposure_id)
@@ -261,9 +277,9 @@ class InstrumentTable:
         schema_table = self.get_flexible_metadata_schema(obs_type)
         stmt = sqlalchemy.select(schema_table.c["key", "dtype", "doc", "unit", "ucd"])
         self.logger.debug(str(stmt))
-        db = next(self.get_db())
-        for row in db.execute(stmt):
-            schema[row[0]] = row[1:]
+        with self._borrow_db() as db:
+            for row in db.execute(stmt):
+                schema[row[0]] = row[1:]
         self.flexible_metadata_schemas[obs_type] = schema
 
     def compute_flexible_metadata_table_name(self, obs_type: str) -> str:

--- a/python/lsst/consdb/dependencies.py
+++ b/python/lsst/consdb/dependencies.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+from functools import cache
 from typing import Annotated
 
 from fastapi import Depends, Path, Request
@@ -38,7 +39,6 @@ _database_url = None
 _engine = None
 _SessionLocal = None
 _instrument_tables: dict[str, InstrumentTable] = dict()
-_instrument_list: list[str] | None = None
 
 
 def get_engine():
@@ -82,7 +82,6 @@ def get_logger(request: Request):
 
 
 def get_instrument_table(instrument: str, engine: Engine = Depends(get_engine)):
-    # global _instrument_list
     # global _instrument_tables
 
     instrument = validate_instrument_name(instrument)
@@ -97,13 +96,10 @@ def get_instrument_table(instrument: str, engine: Engine = Depends(get_engine)):
     return instrument_table
 
 
+@cache
 def get_instrument_list():
-    # global _instrument_list
-    if _instrument_list is None:
-        inspector = inspect(get_engine())
-        instrument_list = [name[4:] for name in inspector.get_schema_names() if name.startswith("cdb_")]
-
-    return instrument_list
+    inspector = inspect(get_engine())
+    return [name[4:] for name in inspector.get_schema_names() if name.startswith("cdb_")]
 
 
 def validate_instrument_name(
@@ -120,9 +116,9 @@ InstrumentName = Annotated[str, AfterValidator(validate_instrument_name)]
 
 
 def reset_dependencies():
-    global _database_url, _engine, _SessionLocal, _instrument_tables, _instrument_list
+    global _database_url, _engine, _SessionLocal, _instrument_tables
     _database_url = None
     _engine = None
     _SessionLocal = None
     _instrument_tables = dict()
-    _instrument_list = None
+    get_instrument_list.cache_clear()

--- a/python/lsst/consdb/handlers/external.py
+++ b/python/lsst/consdb/handlers/external.py
@@ -705,7 +705,7 @@ def query(
     rows are discarded.
     """
 
-    logger.info("pqserver query endpoint:\n{query!r}")
+    logger.info("pqserver query endpoint:\n%r", data.query)
 
     columns = []
     rows = []


### PR DESCRIPTION
This change fixes connection cleanup in the helper functions that cross reference exposure ID to `day_obs`/`seq_num`/`[detector]`.

Two other bugs are also addressed, for a cached lookup and for a formatted print statement.